### PR TITLE
chore: update host plugin marketplace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "atomicmemory",
+  "metadata": {
+    "description": "AtomicMemory coding-agent plugins for persistent semantic memory."
+  },
+  "owner": {
+    "name": "AtomicMemory",
+    "url": "https://atomicmem.ai"
+  },
+  "plugins": [
+    {
+      "name": "claude-code",
+      "source": "./plugins/claude-code",
+      "description": "Persistent semantic memory for Claude Code - user preferences, project context, prior decisions, and codebase facts that survive across sessions.",
+      "version": "0.1.15",
+      "category": "productivity",
+      "homepage": "https://docs.atomicstrata.ai/integrations/coding-agents/claude-code",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -21,8 +21,8 @@ OpenClaw passes config from `openclaw.plugin.json` into the plugin entrypoint:
 
 ```json
 {
-  "apiUrl": "https://memory.yourco.com",
-  "apiKey": "am_live_...",
+  "apiUrl": "http://127.0.0.1:3050",
+  "apiKey": "local-dev-key",
   "provider": "atomicmemory",
   "scope": {
     "user": "pip",
@@ -31,6 +31,10 @@ OpenClaw passes config from `openclaw.plugin.json` into the plugin entrypoint:
   }
 }
 ```
+
+The shipped skill permissions allow only local AtomicMemory core origins:
+`http://127.0.0.1:3050` and `http://localhost:3050`. Remote providers require
+a separately permissioned plugin manifest and host validation.
 
 `scope.user` is required and should be the stable channel-agnostic user identity. Optional `agent`, `namespace`, and `thread` narrow memory when needed. The plugin normalizes the API URL, strips whitespace from the API key, and drops empty optional scope fields before spawning the MCP server.
 

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -14,17 +14,17 @@
     "properties": {
       "apiUrl": {
         "type": "string",
-        "description": "Optional provider base URL. Defaults to the local AtomicMemory core for provider=atomicmemory. Required for provider=mem0."
+        "description": "Optional provider base URL. Defaults to the local AtomicMemory core. The shipped skill permissions allow http://127.0.0.1:3050 and http://localhost:3050."
       },
       "apiKey": {
         "type": "string",
-        "description": "Optional bearer credential forwarded to AtomicMemory core as Authorization: Bearer <apiKey>."
+        "description": "Optional bearer credential forwarded to an allowed local AtomicMemory core as Authorization: Bearer <apiKey>."
       },
       "provider": {
         "type": "string",
         "enum": ["atomicmemory", "mem0"],
         "default": "atomicmemory",
-        "description": "Provider name dispatched through the SDK's MemoryProvider model. Defaults to AtomicMemory local core."
+        "description": "Provider name dispatched through the SDK's MemoryProvider model. Defaults to AtomicMemory local core; remote providers require a separately permissioned plugin manifest."
       },
       "scope": {
         "type": "object",


### PR DESCRIPTION
## Summary
- add the root Claude marketplace index pointing at `plugins/claude-code`
- align OpenClaw manifest copy with its shipped local-only skill permissions
- update OpenClaw README config example to use local core origins

## Validation
- `jq . .claude-plugin/marketplace.json plugins/openclaw/openclaw.plugin.json >/dev/null`
- `pnpm run package-metadata`
- `pnpm run repo-hygiene`
- `pnpm --filter @atomicmemory/claude-code-plugin test`
- `pnpm --filter @atomicmemory/openclaw-plugin typecheck`
- `pnpm --filter @atomicmemory/openclaw-plugin test`
- `pnpm run public-integration-smoke`
- `pnpm run pack-dry-run`
- `git diff --check HEAD~1..HEAD`
