### PR TITLE
release: bump host plugins to 0.1.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-code",
       "source": "./plugins/claude-code",
       "description": "Persistent semantic memory for Claude Code - user preferences, project context, prior decisions, and codebase facts that survive across sessions.",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "category": "productivity",
       "homepage": "https://docs.atomicstrata.ai/integrations/coding-agents/claude-code",
       "license": "Apache-2.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atomicmemory",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Persistent semantic memory for Claude Code — user preferences, project context, prior decisions, and codebase facts that survive across sessions.",
   "author": {
     "name": "AtomicMemory",

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/claude-code-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory plugin for Claude Code — persistent semantic memory across sessions.",
   "private": false,
   "license": "Apache-2.0",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atomicmemory",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory memory layer for Codex. Pluggable semantic memory — swap backends through the SDK's MemoryProvider model by config, not code change.",
   "author": {
     "name": "AtomicMemory",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/codex-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory plugin for OpenAI Codex — plugin manifest, MCP server config, and memory protocol skill.",
   "private": true,
   "license": "Apache-2.0",

--- a/plugins/codex/skills/atomicmemory/SKILL.md
+++ b/plugins/codex/skills/atomicmemory/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: AtomicMemory
-  version: "0.1.15"
+  version: "0.1.16"
   category: ai-memory
   tags: "memory, semantic-search, codex, pluggable"
 ---

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/cursor-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory integration for Cursor - MCP configuration and project rules for persistent semantic memory.",
   "private": true,
   "license": "Apache-2.0",

--- a/plugins/hermes/package.json
+++ b/plugins/hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/hermes-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory native Hermes memory provider — Python SDK-backed, cross-tool memory by default.",
   "publishConfig": {
     "access": "public",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: atomicmemory
-version: 0.1.15
+version: 0.1.16
 description: "AtomicMemory native Hermes memory provider — Python SDK-backed, cross-tool memory by default."
 pip_dependencies:
   - "atomicmemory>=1.0.1,<2.0.0"

--- a/plugins/hermes/pyproject.toml
+++ b/plugins/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atomicmemory-hermes"
-version = "0.1.15"
+version = "0.1.16"
 description = "AtomicMemory native Hermes memory provider."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "atomicmemory",
   "name": "AtomicMemory",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Persistent semantic memory for OpenClaw agents — cross-channel user memory and deterministic session snapshots via the AtomicMemory SDK's pluggable MemoryProvider model.",
   "kind": "memory",
   "skills": ["./skills/atomicmemory"],

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/openclaw-plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AtomicMemory plugin for OpenClaw — persistent semantic memory and deterministic session snapshots across channels.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/openclaw/skills/atomicmemory/skill.yaml
+++ b/plugins/openclaw/skills/atomicmemory/skill.yaml
@@ -1,5 +1,5 @@
 name: atomicmemory
-version: 0.1.15
+version: 0.1.16
 author:
   name: AtomicMemory
   url: https://atomicmem.ai


### PR DESCRIPTION
## Summary
- bump host plugin metadata from `0.1.15` to `0.1.16` lock-step
- include Claude marketplace metadata, OpenClaw skill/manifest metadata, Hermes plugin metadata, and private Codex/Cursor package metadata

## Validation
- `npm view @atomicmemory/claude-code-plugin@0.1.16 version --registry=https://registry.npmjs.org/ || true` confirmed not published
- `npm view @atomicmemory/openclaw-plugin@0.1.16 version --registry=https://registry.npmjs.org/ || true` confirmed not published
- `npm view @atomicmemory/hermes-plugin@0.1.16 version --registry=https://registry.npmjs.org/ || true` confirmed not published
- `pnpm run package-metadata`
- `pnpm run repo-hygiene`
- `pnpm --filter @atomicmemory/claude-code-plugin test`
- `pnpm --filter @atomicmemory/openclaw-plugin typecheck`
- `pnpm --filter @atomicmemory/openclaw-plugin test`
- `pnpm run public-integration-smoke`
- `pnpm run pack-dry-run`
- `git diff --check`
