### PR TITLE
Enable Codex OAuth support in @atomicmemory/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Open-source memory engine for AI applications — semantic retrieval, AUDN mutation, and contradiction-safe claim versioning.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bump `@atomicmemory/core` to include Codex OAuth compatibility.

## Changes

- Advance `@atomicmemory/core` version to `1.0.5`.

## Why

Codex requires an updated core release to support OAuth-based authentication flows. This version entry is the prerequisite for consumers that depend on the Codex OAuth path.

## Validation

- `pnpm run package-metadata` — confirms package manifest is valid.
- `pnpm run pack-dry-run` — confirms publishable artifact is well-formed.