### PR TITLE
Expose latest SDK and integration updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-code",
       "source": "./plugins/claude-code",
       "description": "Persistent semantic memory for Claude Code - user preferences, project context, prior decisions, and codebase facts that survive across sessions.",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "category": "productivity",
       "homepage": "https://docs.atomicstrata.ai/integrations/coding-agents/claude-code",
       "license": "Apache-2.0"

--- a/adapters/langchain/package.json
+++ b/adapters/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/langchain",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AtomicMemory adapter for LangChain JS - memory tools and framework-agnostic retrieve/ingest helpers around an injected MemoryClient.",
   "type": "module",
   "main": "dist/index.js",

--- a/adapters/langgraph/package.json
+++ b/adapters/langgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/langgraph",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AtomicMemory adapter for LangGraph JS - state-graph node factories around an injected MemoryClient.",
   "type": "module",
   "main": "dist/index.js",

--- a/adapters/mastra/package.json
+++ b/adapters/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/mastra",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AtomicMemory adapter for Mastra - memory tools around an injected MemoryClient.",
   "type": "module",
   "main": "dist/index.js",

--- a/adapters/openai-agents/package.json
+++ b/adapters/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/openai-agents",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AtomicMemory adapter for the OpenAI Agents SDK — pre-run memory retrieval, post-run ingest, and function tools.",
   "type": "module",
   "main": "dist/index.js",

--- a/adapters/vercel-ai/package.json
+++ b/adapters/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/vercel-ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AtomicMemory adapter for the Vercel AI SDK — pre-call memory retrieval + post-call ingest, framework-version-agnostic.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/cli-spec.json
+++ b/packages/cli/cli-spec.json
@@ -1,7 +1,7 @@
 {
   "spec_version": "5.0.0",
   "package_name": "@atomicmemory/cli",
-  "package_version": "0.1.2",
+  "package_version": "0.1.3",
   "global_options": [
     {
       "name": "--json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AtomicMemory CLI for memory operations, config, status, and agent-friendly JSON output.",
   "type": "module",
   "publishConfig": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server exposing AtomicMemory's ingest / search / package tools to any MCP-compatible agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atomicmemory",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Persistent semantic memory for Claude Code — user preferences, project context, prior decisions, and codebase facts that survive across sessions.",
   "author": {
     "name": "AtomicMemory",

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/claude-code-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory plugin for Claude Code — persistent semantic memory across sessions.",
   "private": false,
   "license": "Apache-2.0",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atomicmemory",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory memory layer for Codex. Pluggable semantic memory — swap backends through the SDK's MemoryProvider model by config, not code change.",
   "author": {
     "name": "AtomicMemory",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/codex-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory plugin for OpenAI Codex — plugin manifest, MCP server config, and memory protocol skill.",
   "private": true,
   "license": "Apache-2.0",

--- a/plugins/codex/skills/atomicmemory/SKILL.md
+++ b/plugins/codex/skills/atomicmemory/SKILL.md
@@ -10,7 +10,7 @@ description: >
 license: Apache-2.0
 metadata:
   author: AtomicMemory
-  version: "0.1.16"
+  version: "0.1.17"
   category: ai-memory
   tags: "memory, semantic-search, codex, pluggable"
 ---

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/cursor-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory integration for Cursor - MCP configuration and project rules for persistent semantic memory.",
   "private": true,
   "license": "Apache-2.0",

--- a/plugins/hermes/package.json
+++ b/plugins/hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/hermes-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory native Hermes memory provider — Python SDK-backed, cross-tool memory by default.",
   "publishConfig": {
     "access": "public",

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: atomicmemory
-version: 0.1.16
+version: 0.1.17
 description: "AtomicMemory native Hermes memory provider — Python SDK-backed, cross-tool memory by default."
 pip_dependencies:
   - "atomicmemory>=1.0.1,<2.0.0"

--- a/plugins/hermes/pyproject.toml
+++ b/plugins/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atomicmemory-hermes"
-version = "0.1.16"
+version = "0.1.17"
 description = "AtomicMemory native Hermes memory provider."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "atomicmemory",
   "name": "AtomicMemory",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Persistent semantic memory for OpenClaw agents — cross-channel user memory and deterministic session snapshots via the AtomicMemory SDK's pluggable MemoryProvider model.",
   "kind": "memory",
   "skills": ["./skills/atomicmemory"],

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/openclaw-plugin",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AtomicMemory plugin for OpenClaw — persistent semantic memory and deterministic session snapshots across channels.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/openclaw/skills/atomicmemory/skill.yaml
+++ b/plugins/openclaw/skills/atomicmemory/skill.yaml
@@ -1,5 +1,5 @@
 name: atomicmemory
-version: 0.1.16
+version: 0.1.17
 author:
   name: AtomicMemory
   url: https://atomicmem.ai


### PR DESCRIPTION
## Summary

Update package metadata so users can install the current SDK, CLI, MCP server, framework adapters, and host integration plugins from public registries.

## Changes

- Update SDK package metadata.
- Update CLI and MCP server package metadata.
- Update framework adapter package metadata.
- Update Claude Code, Codex, Cursor, Hermes, and OpenClaw plugin metadata.
- Update Hermes Python package metadata.

## Why

The source already includes the current SDK and integration updates. Package metadata needs to move so npm and PyPI artifacts can carry those updates to users.

## Validation

- Internal CI passed before public sync.
