### PR TITLE
Fix core migrate binary to call programmatic migration API

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `newer_db` / `unstamped` / `no_schema`) is unchanged.
 
 ### Changed
+- The published `atomicmemory-core migrate` command now calls the
+  programmatic migration API directly, so npm installs can run the documented
+  migration command without the command word being reparsed as a migration
+  option.
 - **BREAKING**: All API endpoints are now mounted under `/v1/` (e.g. `POST /v1/memories/ingest`, `PUT /v1/agents/trust`). Update clients to prefix requests with `/v1`. The unversioned `/health` liveness probe is unchanged.
 - Phase 2 removes `src/db/schema.sql`; the migrations folder is now the
   single source of truth. The build-time `dist/db/schema-sha256.json`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmemory/core",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Open-source memory engine for AI applications — semantic retrieval, AUDN mutation, and contradiction-safe claim versioning.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/core/src/__tests__/bin.test.ts
+++ b/packages/core/src/__tests__/bin.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the published `atomicmemory-core` npm binary entry point.
+ *
+ * These cover command dispatch only; migration behavior itself lives in the
+ * migration API test suite. The key regression guard is that `migrate` must
+ * call the programmatic API directly instead of importing the standalone
+ * migration CLI, which reparses the original process argv.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  migrate: vi.fn(),
+}));
+
+vi.mock('../db/migration-api.js', () => ({
+  migrate: mocks.migrate,
+}));
+
+vi.mock('../db/migrate.js', () => {
+  throw new Error('standalone migration CLI must not be imported by bin.ts');
+});
+
+import { parseCliArgs, runCommand } from '../bin.js';
+
+describe('core CLI entry point', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    mocks.migrate.mockResolvedValue({
+      ranSchemaSql: true,
+      schemaVersion: {
+        sdkVersion: '1.0.6',
+        schemaSha256: 'abcdef1234567890',
+        appliedAt: new Date('2026-05-20T00:00:00.000Z'),
+        notes: null,
+      },
+      reconciledEmbeddingDimension: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses the local migrate command without passing command text onward', () => {
+    expect(parseCliArgs(['migrate', '--profile', 'local'])).toEqual({
+      command: 'migrate',
+      help: false,
+      profile: 'local',
+    });
+  });
+
+  it('runs migrations through the programmatic API', async () => {
+    await runCommand('migrate');
+
+    expect(mocks.migrate).toHaveBeenCalledOnce();
+    expect(mocks.migrate).toHaveBeenCalledWith();
+    expect(console.log).toHaveBeenCalledWith(
+      '[migrate] Migration complete (ranSchemaSql=true, version=1.0.6, sha=abcdef123456..., reconciledEmbeddingDimension=false).',
+    );
+  });
+});

--- a/packages/core/src/bin.ts
+++ b/packages/core/src/bin.ts
@@ -107,12 +107,20 @@ function assertLocalProfileReady(): void {
   );
 }
 
-async function runCommand(command: CommandName): Promise<void> {
+export async function runCommand(command: CommandName): Promise<void> {
   if (command === 'start') {
     await import('./server.js');
     return;
   }
-  await import('./db/migrate.js');
+  const { migrate } = await import('./db/migration-api.js');
+  const result = await migrate();
+  console.log(
+    `[migrate] Migration complete ` +
+      `(ranSchemaSql=${result.ranSchemaSql}, ` +
+      `version=${result.schemaVersion.sdkVersion}, ` +
+      `sha=${result.schemaVersion.schemaSha256.slice(0, 12)}..., ` +
+      `reconciledEmbeddingDimension=${result.reconciledEmbeddingDimension}).`,
+  );
 }
 
 async function main(argv: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

Fix the published `atomicmemory-core` binary so that `atomicmemory-core migrate` works correctly for npm installs. Previously the `migrate` command imported the standalone migration CLI, which reparsed `process.argv` and treated the command word `migrate` as a migration option, breaking the documented workflow.

## Changes

- `bin.ts`: Route the `migrate` command through `migration-api.migrate()` directly instead of importing the standalone `migrate.js` CLI.
- `bin.ts`: Export `runCommand` and `parseCliArgs` so the dispatch logic is testable without spawning a subprocess.
- `bin.test.ts`: Add CLI dispatch regression test that guards against `migrate.js` being re-imported and verifies the programmatic API receives the call.
- `CHANGELOG.md`: Document the fix and the new behavior.

## Why

The standalone `migrate.js` module re-reads `process.argv` when imported, so invoking `atomicmemory-core migrate` caused the string `"migrate"` to be reparsed as a migration option rather than the command name. The programmatic `migration-api.migrate()` function accepts no argv and applies migrations directly, which is the correct path for a CLI dispatch layer.

## Validation

- New `bin.test.ts` confirms `parseCliArgs` strips the command word correctly and that `runCommand('migrate')` calls `migration-api.migrate()` exactly once without ever importing `migrate.js`.
- The mock guard in the test (`throw new Error(...)`) ensures the regression cannot silently reappear.