### PR TITLE
ci(publish): dispatch full image-lane smoke after GHCR push

### DIFF
--- a/.github/workflows/publish-core-docker.yml
+++ b/.github/workflows/publish-core-docker.yml
@@ -317,3 +317,55 @@ jobs:
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:latest" \
             "${IMAGE_NAME}:${{ steps.package.outputs.version }}"
+
+      - name: Dispatch full image-lane integration smoke
+        # Fires only after a fresh GHCR push so the smoke validates a new
+        # artifact, not a retag of an already-validated digest.
+        #
+        # Required configuration (provisioned in repo Settings → Secrets
+        # and variables → Actions):
+        #   secret  IMAGE_SMOKE_DISPATCH_TOKEN  fine-grained PAT scoped to
+        #                                       the smoke repo with
+        #                                       `actions: write`.
+        #   var     IMAGE_SMOKE_REPO            owner/name of the
+        #                                       repo that listens for the
+        #                                       `core-image-published`
+        #                                       repository_dispatch event.
+        #
+        # Fails closed if either is unset so a missing dispatch is loud,
+        # not a silent gap that lets a regression ship.
+        if: steps.package.outputs.should_publish == 'true' && steps.package.outputs.retag_latest_only != 'true'
+        env:
+          IMAGE_SMOKE_DISPATCH_TOKEN: ${{ secrets.IMAGE_SMOKE_DISPATCH_TOKEN }}
+          IMAGE_SMOKE_REPO: ${{ vars.IMAGE_SMOKE_REPO }}
+          CORE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${IMAGE_SMOKE_DISPATCH_TOKEN:-}" ]; then
+            echo "::error::IMAGE_SMOKE_DISPATCH_TOKEN secret is not configured; cannot dispatch the full image-lane smoke."
+            exit 1
+          fi
+          if [ -z "${IMAGE_SMOKE_REPO:-}" ]; then
+            echo "::error::IMAGE_SMOKE_REPO variable is not configured; cannot determine the dispatch target."
+            exit 1
+          fi
+          image_digest="$(docker manifest inspect "${IMAGE_NAME}:${CORE_VERSION}" --verbose | jq -r '
+            if type == "array" then .[0].Descriptor.digest else .Descriptor.digest // empty end
+          ')"
+          if [ -z "${image_digest}" ] || [ "${image_digest}" = "null" ]; then
+            echo "::error::Failed to read manifest digest for ${IMAGE_NAME}:${CORE_VERSION} after push."
+            exit 1
+          fi
+          payload="$(jq -n \
+            --arg core_version "${CORE_VERSION}" \
+            --arg image_ref "${IMAGE_NAME}:${CORE_VERSION}" \
+            --arg image_digest "${image_digest}" \
+            '{event_type:"core-image-published", client_payload:{core_version:$core_version, image_ref:$image_ref, image_digest:$image_digest}}')"
+          curl -fsS \
+            -X POST \
+            -H "Authorization: Bearer ${IMAGE_SMOKE_DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "${payload}" \
+            "https://api.github.com/repos/${IMAGE_SMOKE_REPO}/dispatches"
+          echo "Dispatched core-image-published for ${IMAGE_NAME}:${CORE_VERSION} (${image_digest})."


### PR DESCRIPTION
## Summary

After publish-core-docker.yml pushes a new GHCR tag, this dispatches a `repository_dispatch: core-image-published` event so a downstream environment can run the full release-required integration suite against the just-pushed image. Adds coverage for MCP, framework adapters, host-tools E2E, hygiene, and docs-contract on top of the existing in-workflow ingest/search smoke.

Fires only after a fresh push (`retag_latest_only=false`); a retag of an already-validated digest is skipped.

## Wiring

The downstream listener and its preflight live elsewhere; this PR is the sender only. Repository configuration required before the dispatch can succeed:

- **Secret** `IMAGE_SMOKE_DISPATCH_TOKEN` — fine-grained PAT with `actions: write` on the target repo.
- **Variable** `IMAGE_SMOKE_REPO` — `owner/name` of the listener.

The workflow file does not hardcode either value; both are pulled from repo settings. If either is unset the step exits non-zero with a clear error so a missed dispatch is loud, not silent.

## Payload

```
event_type: core-image-published
client_payload:
  core_version: <x.y.z>
  image_ref:    ghcr.io/atomicstrata/atomicmemory-core:<x.y.z>
  image_digest: sha256:...
```

The digest is read from `docker manifest inspect` after the push so the listener can pin to a specific image content if it wants to.

## Test plan

- [x] `pnpm run repo-hygiene` passes.
- [x] `pnpm run security-compliance` passes.
- [x] Workflow YAML parses cleanly with the new step appended at the end.
- [ ] First publish after merge dispatches successfully (visible in repo Actions → workflow runs).
- [ ] Listener receives the event and the full smoke runs against the new image.
